### PR TITLE
Check HP modifier when modifying combatant HP

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <template>
   <v-app>
-    <v-content class="background: blue lighten-3">
+    <v-main class="background: blue lighten-3">
       <router-view name="header-top"></router-view>
       <transition name="slide" mode="out-in">
         <router-view></router-view>
       </transition>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 

--- a/src/components/combatants/CombatantForm.vue
+++ b/src/components/combatants/CombatantForm.vue
@@ -144,7 +144,9 @@ export default {
         v =>
           (v && v >= 0) || "Initiative score must be greater than or equal to 0"
       ],
-      armorClass: [v => (v && v >= 0) || "Armor class must be greater than or equal to 0"],
+      armorClass: [
+        v => (v && v >= 0) || "Armor class must be greater than or equal to 0"
+      ],
       currentHP: [v => (v && v >= 0) || "Current HP must be at least 0"],
       passPerception: [
         v => (v && v >= 5) || "Passive perception must be at least 5"

--- a/src/components/combatants/CombatantList.vue
+++ b/src/components/combatants/CombatantList.vue
@@ -7,9 +7,9 @@
             ><v-icon v-text="icons.combatants"></v-icon
           ></v-list-item-avatar>
           <v-list-item-content
-            ><v-list-item-title class="headline mb-1"
-              >{{ title }}</v-list-item-title
-            ></v-list-item-content
+            ><v-list-item-title class="headline mb-1">{{
+              title
+            }}</v-list-item-title></v-list-item-content
           >
         </v-list-item>
       </v-card-title>
@@ -82,7 +82,7 @@
               <td>
                 <tracker-tooltip-btn
                   :btn-class="'info'"
-                  :click-action="function() { editCombatant(combatant.id); }"
+                  :click-action="editCombatant(combatant.id)"
                   :icon="icons.edit"
                   :showing="true"
                   >Edit Combatant</tracker-tooltip-btn

--- a/src/components/tracker/Tracker.vue
+++ b/src/components/tracker/Tracker.vue
@@ -70,7 +70,11 @@
                     max-width="500"
                   >
                     <template #activator="{ on }">
-                      <v-btn @click="setDialogTarget(combatant)" v-on="on" small
+                      <v-btn
+                        @click="setDialogTarget(combatant)"
+                        v-on="on"
+                        small
+                        :disabled="!encounter.started"
                         ><v-icon small v-text="icons.pencil"></v-icon
                       ></v-btn>
                     </template>
@@ -372,6 +376,9 @@ export default {
       this.dialogs.hp.combatant = combatant;
     },
     modifyHP(modifier) {
+      if (isNaN(modifier) || modifier == null) {
+        return;
+      }
       this.dialogs.hp.combatant.currentHP += parseInt(modifier);
       this.dialogs.hp.show = false;
       this.dialogs.hp.modifier = null;


### PR DESCRIPTION
Check that the provided HP modifier is neither `NaN` nor `null` when modifying a combatant's HP. Disabled editing combatants' HP when the encounter has not been started to prevent a stack overflow.

Resolves #1 